### PR TITLE
Adding publicPath option.

### DIFF
--- a/src/WebpackAssetsManifest.js
+++ b/src/WebpackAssetsManifest.js
@@ -33,7 +33,8 @@ function WebpackAssetsManifest(options)
     writeToDisk: false,
     fileExtRegex: /\.\w{2,4}\.(?:map|gz)$|\.\w+$/i,
     sortManifest: true,
-    merge: false
+    merge: false,
+    publicPath: '',
   };
 
   this.options = pick(
@@ -112,7 +113,7 @@ WebpackAssetsManifest.prototype.fixKey = function(key)
  */
 WebpackAssetsManifest.prototype.set = function(key, value)
 {
-  this.assets[ this.fixKey(key) ] = value;
+  this.assets[ this.fixKey(key) ] = this.options.publicPath+value;
 
   return this;
 };

--- a/src/WebpackAssetsManifest.js
+++ b/src/WebpackAssetsManifest.js
@@ -113,7 +113,7 @@ WebpackAssetsManifest.prototype.fixKey = function(key)
  */
 WebpackAssetsManifest.prototype.set = function(key, value)
 {
-  this.assets[ this.fixKey(key) ] = this.options.publicPath+value;
+  this.assets[ this.fixKey(key) ] = this.options.publicPath + value;
 
   return this;
 };

--- a/test/WebpackAssetsManifest-test.js
+++ b/test/WebpackAssetsManifest-test.js
@@ -161,7 +161,9 @@ describe('WebpackAssetsManifest', function() {
 
   describe('#set()', function() {
     it('should add to manifest.assets', function() {
-      var manifest = new WebpackAssetsManifest();
+      var manifest = new WebpackAssetsManifest({
+        publicPath: 'http://cdn.xyz.com/'
+      });
 
       assert.deepEqual({}, manifest.assets);
 
@@ -170,8 +172,8 @@ describe('WebpackAssetsManifest', function() {
 
       assert.deepEqual(
         {
-          'main.js': 'main.123456.js',
-          'styles/main.css': 'styles/main.123456.css'
+          'main.js': 'http://cdn.xyz.com/main.123456.js',
+          'styles/main.css': 'http://cdn.xyz.com/styles/main.123456.css'
         },
         manifest.assets
       );

--- a/test/WebpackAssetsManifest-test.js
+++ b/test/WebpackAssetsManifest-test.js
@@ -160,7 +160,7 @@ describe('WebpackAssetsManifest', function() {
   });
 
   describe('#set()', function() {
-    it('should add to manifest.assets', function() {
+    it('should add to manifest.assets prepended with publicPath', function() {
       var manifest = new WebpackAssetsManifest({
         publicPath: 'http://cdn.xyz.com/'
       });


### PR DESCRIPTION
Adding publicPath option. urlloaders don't just emit files, they also create urls using publicPath supplied. This comes in handy if somebody wants to hardcode an asset url in an html template, which in production will be served from CDN.

eg: 

```
{ 
    'client.js': 'http://xyz.cdn.com/client-374df08c.js
}
```
