### PR TITLE
Add a hook to change the asset key

### DIFF
--- a/src/WebpackAssetsManifest.js
+++ b/src/WebpackAssetsManifest.js
@@ -182,6 +182,18 @@ WebpackAssetsManifest.prototype.delete = function(key)
 };
 
 /**
+ * Returns the key that will be associated to the asset in manifest.json
+ *
+ * Override it if you want something different that the entry's name + file extension as key
+ * @param  {object} entryName - entry name
+ * @param  {object} filename - filename of the asset
+ * @return {object}
+ */
+ WebpackAssetsManifest.prototype.getAssetKey = function (entryName, filename) {
+  return entryName + this.getExtension( filename );
+ };
+
+/**
  * Process compilation assets.
  *
  * @param  {object} assets - assets by chunk name
@@ -201,13 +213,14 @@ WebpackAssetsManifest.prototype.processAssets = function(assets)
     }
 
     for ( var i = 0, l = filenames.length; i < l ; ++i ) {
-      var filename = name + this.getExtension( filenames[ i ] );
+      var filename = filenames[ i ],
+          assetKey = this.getAssetKey(name, filename);
 
-      if ( this.isHMR( filenames[ i ] ) ) {
+      if ( this.isHMR( filename ) ) {
         continue;
       }
 
-      this.set( filename, filenames[ i ] );
+      this.set( assetKey, filename );
     }
   }
 

--- a/test/WebpackAssetsManifest-test.js
+++ b/test/WebpackAssetsManifest-test.js
@@ -109,6 +109,39 @@ describe('WebpackAssetsManifest', function() {
     });
   });
 
+  describe('#overridegetAssetKey()', function() {
+    var manifest = new WebpackAssetsManifest();
+
+    it('should process assets with the given key function', function() {
+      assert.deepEqual({}, manifest.assets);
+
+      manifest.getAssetKey = function (name, filename) {
+        return path.join(path.dirname(filename), name) + this.getExtension(filename);
+      };
+
+      manifest.processAssets({
+        common: [
+          'js/common-123456.js',
+          'js/common-123456.js.map'
+        ],
+        main: [
+          'css/main.123456.css',
+          'css/main.123456.css.map'
+        ]
+      });
+
+      assert.deepEqual(
+        {
+          'js/common.js': 'js/common-123456.js',
+          'js/common.js.map': 'js/common-123456.js.map',
+          'css/main.css': 'css/main.123456.css',
+          'css/main.css.map': 'css/main.123456.css.map'
+        },
+        manifest.assets
+      );
+    });
+  });
+
   describe('#getStatsData()', function() {
     it('should return statistics from webpack', function() {
       var manifest = new WebpackAssetsManifest();


### PR DESCRIPTION
Related to #10 

With this hook, one can modify the key that will be written in the `manifest.json` file.

My use case is that I'd rather have two different folders for `css` and `js` assets.

I am not a webpack expert so any feedback welcomed :)