### PR TITLE
Get only needed stats to greatly reduce memory consumption

### DIFF
--- a/src/WebpackAssetsManifest.js
+++ b/src/WebpackAssetsManifest.js
@@ -442,7 +442,10 @@ class WebpackAssetsManifest
    */
   handleEmit(compilation, callback)
   {
-    this.stats = compilation.getStats().toJson();
+    this.stats = compilation.getStats().toJson({
+      all: false,
+      assets: true,
+    });
 
     this.processAssetsByChunkName( this.stats.assetsByChunkName );
 


### PR DESCRIPTION
I stumbled into an allocation error when trying this manifest plugin:

```
 95% emitting WebpackAssetsManifest                                                                                     
<--- Last few GCs --->

[79715:0x104002800]   310074 ms: Scavenge 3481.1 (4172.2) -> 3480.3 (4183.7) MB, 14.3 / 0.0 ms  (average mu = 0.300, current mu = 0.380) allocation failure 
[79715:0x104002800]   310425 ms: Mark-sweep 3491.2 (4183.7) -> 3490.2 (4168.7) MB, 315.3 / 0.0 ms  (average mu = 0.256, current mu = 0.168) allocation failure scavenge might not succeed
[79715:0x104002800]   310454 ms: Scavenge 3495.1 (4168.7) -> 3494.4 (4179.7) MB, 14.0 / 0.0 ms  (average mu = 0.256, current mu = 0.168) allocation failure 


<--- JS stacktrace --->

==== JS stack trace =========================================

    0: ExitFrame [pc: 0xcb64b24fc7d]
Security context: 0x12e43151d949 <JSObject>
    1: DoJoin(aka DoJoin) [0x12e431505de9] [native array.js:~89] [pc=0xcb64c7cb622](this=0x12e40ed025b1 <undefined>,0x12e42b2726b9 <JSArray[3171]>,3171,0x12e40ed02741 <true>,0x12e40ed09109 <String[1]:  >,0x12e40ed02801 <false>,0x12e40ed025b1 <undefined>,0x12e40ed025b1 <undefined>)
    2: Join(aka Join) [0x12e431505e39] [native array.js:~115] [pc=0xcb64b5e0907...

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
 1: 0x100060c8f node::Abort() [/usr/local/Cellar/node/11.8.0/bin/node]
 2: 0x10006134f node::OnFatalError(char const*, char const*) [/usr/local/Cellar/node/11.8.0/bin/node]
 3: 0x1001749ff v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [/usr/local/Cellar/node/11.8.0/bin/node]
 4: 0x1001749a0 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [/usr/local/Cellar/node/11.8.0/bin/node]
 5: 0x1004300bc v8::internal::Heap::UpdateSurvivalStatistics(int) [/usr/local/Cellar/node/11.8.0/bin/node]
```

Raising limits with `NODE_OPTIONS="--max-old-space-size=4096"` was not enough.

Following what one of my team mate did on the plugin we currently use to actually fix the same memory error we had with it (see https://github.com/danethurber/webpack-manifest-plugin/pull/174/files) here is a PR that do the same here (and better with the catchall `all` option) should fix the issue.

Cheerz.