### PR TITLE
add preload / prefetch assets to "entrypoints"

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "mocha": "^7.2.0",
     "nyc": "^15.0.0",
     "rimraf": "^3.0.2",
+    "semver": "^5.6.0",
     "superagent": "^5.2.2",
     "webpack": "^4.43.0",
     "webpack-dev-server": "^3.11.0"

--- a/test/fixtures/configs.js
+++ b/test/fixtures/configs.js
@@ -139,8 +139,43 @@ function multi()
   return [ c, s ];
 }
 
+function entrypoints()
+{
+  const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+
+  return {
+    mode: 'development',
+    entry: path.resolve(__dirname, './entrypoints.js'),
+    output: {
+      path: tmpDirPath(),
+      filename: '[name].js',
+    },
+    module: {
+      rules: [
+        {
+          test: /\.jpg$/i,
+          loader: 'file-loader?name=images/[name].[ext]',
+        },
+        {
+          test: /\.css$/,
+          use: [
+            MiniCssExtractPlugin.loader,
+            'css-loader',
+          ],
+        },
+      ],
+    },
+    plugins: [
+      new MiniCssExtractPlugin({
+        filename: '[name].css',
+      }),
+    ],
+  };
+}
+
 module.exports = {
   hello,
+  entrypoints,
   client,
   server,
   devServer,

--- a/test/fixtures/entrypoints-async.js
+++ b/test/fixtures/entrypoints-async.js
@@ -1,0 +1,1 @@
+console.log('hi');

--- a/test/fixtures/entrypoints-prefetch.css
+++ b/test/fixtures/entrypoints-prefetch.css
@@ -1,0 +1,3 @@
+body {
+  background-color: purple;
+}

--- a/test/fixtures/entrypoints-prefetch.js
+++ b/test/fixtures/entrypoints-prefetch.js
@@ -1,0 +1,1 @@
+console.log('hey');

--- a/test/fixtures/entrypoints-preload.css
+++ b/test/fixtures/entrypoints-preload.css
@@ -1,0 +1,3 @@
+body {
+  background-color: hotpink;
+}

--- a/test/fixtures/entrypoints-preload.js
+++ b/test/fixtures/entrypoints-preload.js
@@ -1,0 +1,1 @@
+console.log('hi');

--- a/test/fixtures/entrypoints.js
+++ b/test/fixtures/entrypoints.js
@@ -1,0 +1,12 @@
+import './styles.css';
+import(/* webpackChunkName: "prefetch-js" */ /* webpackPrefetch: true */ './entrypoints-prefetch');
+import(/* webpackChunkName: "preload-js" */ /* webpackPreload: true */ './entrypoints-preload');
+import(/* webpackChunkName: "prefetch-css" */ /* webpackPrefetch: true */ './entrypoints-prefetch.css');
+import(/* webpackChunkName: "preload-css" */ /* webpackPreload: true */ './entrypoints-preload.css');
+
+// this should not be in "entrypoints", since it's neither preloaded or prefetched
+import(/* webpackChunkName: "async" */ './entrypoints-async.js');
+
+export default function(name) {
+  return 'Hello ' + name;
+}


### PR DESCRIPTION
Fixes #25.

This adds all async chunks that are annotated with either `prefetch` or `preload` to their associated entrypoints in the manifest. The use-case of this will be generating `<link rel='preload|prefetch'>` tags on the server to require those assets, similarly to [GoogleChromeLabs/preload-webpack-plugin](https://github.com/GoogleChromeLabs/preload-webpack-plugin).