### PR TITLE
Support for entrypoints and multi compiler

### DIFF
--- a/src/WebpackAssetsManifest.js
+++ b/src/WebpackAssetsManifest.js
@@ -475,7 +475,10 @@ class WebpackAssetsManifest
           this.setRaw( key, entrypoints[ key ] );
         }
       } else {
-        this.setRaw( this.options.entrypointsKey, entrypoints );
+        const existingEntrypoints = this.assets[ this.options.entrypointsKey ];
+        const mergedEntrypoints = Object.assign({}, existingEntrypoints || {}, entrypoints);
+
+        this.setRaw( this.options.entrypointsKey, mergedEntrypoints);
       }
     }
 

--- a/src/WebpackAssetsManifest.js
+++ b/src/WebpackAssetsManifest.js
@@ -478,7 +478,7 @@ class WebpackAssetsManifest
         const existingEntrypoints = this.assets[ this.options.entrypointsKey ];
         const mergedEntrypoints = Object.assign({}, existingEntrypoints || {}, entrypoints);
 
-        this.setRaw( this.options.entrypointsKey, mergedEntrypoints);
+        this.setRaw( this.options.entrypointsKey, mergedEntrypoints );
       }
     }
 

--- a/src/WebpackAssetsManifest.js
+++ b/src/WebpackAssetsManifest.js
@@ -399,6 +399,10 @@ class WebpackAssetsManifest
         for ( const key in data ) {
           if ( ! this.has(key) ) {
             this.set(key, data[ key ]);
+          } else if (key === this.options.entrypointsKey) {
+            const result = Object.assign({}, this.assets[ key ], data[ key ]);
+
+            this.set(key, result);
           }
         }
       } catch (err) { // eslint-disable-line

--- a/test/WebpackAssetsManifest-test.js
+++ b/test/WebpackAssetsManifest-test.js
@@ -1102,35 +1102,76 @@ describe('WebpackAssetsManifest', function() {
       });
     });
 
-    it('should support multi compiler mode', function(done) {
-      let manifestPath = null;
-      const assets = Object.create(null);
-      const multiConfig = configs.multi().map(function(config) {
-        config.plugins = [
-          new WebpackAssetsManifest({
-            assets,
-          }),
-        ];
+    describe('multi compiler mode', function() {
+      it('should support with default config', function(done) {
+        let manifestPath = null;
+        const assets = Object.create(null);
+        const multiConfig = configs.multi().map(function(config) {
+          config.plugins = [
+            new WebpackAssetsManifest({
+              assets,
+            }),
+          ];
 
-        manifestPath = path.join( config.output.path, 'manifest.json' );
+          manifestPath = path.join( config.output.path, 'manifest.json' );
 
-        return config;
+          return config;
+        });
+
+        webpack(multiConfig, function( err ) {
+          assert.isNull(err, 'Error found in compiler.run');
+
+          fs.readFile(
+            manifestPath,
+            function(err, content) {
+              assert.isNull(err, 'Error found reading manifest.json');
+              assert.include(content.toString(), 'client.js');
+              assert.include(content.toString(), 'server.js');
+              assert.include(content.toString(), 'images/Ginger.jpg');
+
+              done();
+            }
+          );
+        });
       });
 
-      webpack(multiConfig, function( err ) {
-        assert.isNull(err, 'Error found in compiler.run');
+      it('should support with enabled entrypoints', function(done) {
+        let manifestPath = null;
+        const assets = Object.create(null);
+        const multiConfig = configs.multi().map(function(config) {
+          config.plugins = [
+            new WebpackAssetsManifest({
+              assets,
+              entrypoints: true,
+            }),
+          ];
 
-        fs.readFile(
-          manifestPath,
-          function(err, content) {
-            assert.isNull(err, 'Error found reading manifest.json');
-            assert.include(content.toString(), 'client.js');
-            assert.include(content.toString(), 'server.js');
-            assert.include(content.toString(), 'images/Ginger.jpg');
+          manifestPath = path.join( config.output.path, 'manifest.json' );
 
-            done();
-          }
-        );
+          return config;
+        });
+
+        webpack(multiConfig, function( err ) {
+          assert.isNull(err, 'Error found in compiler.run');
+
+          fs.readFile(
+            manifestPath,
+            function(err, content) {
+              assert.isNull(err, 'Error found reading manifest.json');
+              assert.include(content.toString(), 'client.js');
+              assert.include(content.toString(), 'server.js');
+              assert.include(content.toString(), 'images/Ginger.jpg');
+
+              const entrypoints = JSON.parse(content).entrypoints;
+
+              expect(entrypoints).to.contain.keys('server', 'client');
+              expect(entrypoints.server.js).contain('server.js');
+              expect(entrypoints.client.js).contain('client.js');
+
+              done();
+            }
+          );
+        });
       });
     });
   });

--- a/test/fixtures/sample-manifest-lite.json
+++ b/test/fixtures/sample-manifest-lite.json
@@ -1,0 +1,18 @@
+{
+  "file_from_lite.js": "/packs/dropzone-dd25772d733b2fbbfb23.js",
+  "entrypoints": {
+    "lite/lite": {
+      "js": [
+        "/packs/runtime-lite-796953eedafd71e1b438.js",
+        "/packs/lite-common-d3216b904b271a4b7f3f.js",
+        "/packs/lite/lite-8a7dca11678dafa8003d.js"
+      ],
+      "css": [
+        "/packs/css/lite-common-df7b0d45.chunk.css"
+      ],
+      "js.map": [
+        "/packs/lite-common-d3216b904b271a4b7f3f.js.map"
+      ]
+    }
+  }
+}

--- a/test/fixtures/sample-manifest-main.json
+++ b/test/fixtures/sample-manifest-main.json
@@ -1,0 +1,35 @@
+{
+  "file_from_main.js": "/packs/dashboard_tiles-f155098dd3626b5f40c3.js",
+  "entrypoints": {
+    "main/main": {
+      "js": [
+        "/packs/runtime-main-f9a9558341ddb1dbef8e.js",
+        "/packs/vendors-e5b496ed001ca7b8dc29.js",
+        "/packs/accounts/accounts_edit-34d7479ed80d9a23cb64.js"
+      ],
+      "js.map": [
+        "/packs/runtime-main-f9a9558341ddb1dbef8e.js.map",
+        "/packs/vendors-e5b496ed001ca7b8dc29.js.map",
+        "/packs/accounts/accounts_edit-34d7479ed80d9a23cb64.js.map"
+      ],
+      "css": [
+        "/packs/css/vendors-24de378c.chunk.css"
+      ]
+    },
+    "application": {
+      "js": [
+        "/packs/runtime-main-f9a9558341ddb1dbef8e.js",
+        "/packs/vendors-e5b496ed001ca7b8dc29.js",
+        "/packs/application-866e5814acb1ccf281fd.js"
+      ],
+      "js.map": [
+        "/packs/runtime-main-f9a9558341ddb1dbef8e.js.map",
+        "/packs/vendors-e5b496ed001ca7b8dc29.js.map",
+        "/packs/application-866e5814acb1ccf281fd.js.map"
+      ],
+      "css": [
+        "/packs/css/vendors-24de378c.chunk.css"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Thanks for an amazing webpack plugin.

I'm using https://github.com/rails/webpacker (which uses this package https://github.com/rails/webpacker/blob/v4.2.0/package.json#L50) with multiple webpack configs

Webpacker does not have the option to generate different entrypoints using `entrypointsKey`
https://github.com/rails/webpacker/blob/v4.2.0/lib/webpacker/manifest.rb#L26
or use two different manifests
https://github.com/rails/webpacker/blob/v4.2.0/lib/webpacker/configuration.rb#L50

At the moment I have webpacker v. 4.0.7 with this workaround https://github.com/webdeveric/webpack-assets-manifest/issues/48#issuecomment-470443650

When upgrading a webpacker to a version 4.2.0, the workaround above has stopped working

What have I done in this PR:

1. Added support for merging entrypoints when `options.merge=true`
Use case
webpack has multiple configurations: `webpack([{}, {}])`
`options.merge=true`
compile all of this by `parallel-webpack`

2. Added support for merging entrypoints when `options.merge=false`
Use case
webpack has multiple configurations: `webpack([{}, {}])`
`options.merge=false`
compile this in one thread

Example of master + specs from this PR:
https://github.com/webdeveric/webpack-assets-manifest/compare/master...pustovalov:specs-with-master-code
https://travis-ci.com/pustovalov/webpack-assets-manifest/jobs/264353096