### PR TITLE
Optionally include namedChunkGroups

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,8 @@ npm install webpack-assets-manifest@1 --save-dev
   * [`integrityHashes`](#integrityhashes)
   * [`entrypoints`](#entrypoints)
   * [`entrypointsKey`](#entrypointskey)
+  * [`namedChunkGroups`](#namedchunkgroups)
+  * [`namedChunkGroupsKey`](#namedchunkgroupskey)
 * Updated `customize` callback arguments. See [customized](examples/customized.js) example.
 * Removed `contextRelativeKeys` option.
 
@@ -246,6 +248,22 @@ Type: `string`, `boolean`
 Default: `entrypoints`
 
 If this is set to `false`, the `entrypoints` will be added to the root of the manifest.
+
+### `namedChunkGroups`
+
+Type: `boolean`
+
+Default: `false`
+
+Include `compilation.namedChunkGroups` in the manifest file.
+
+### `namedChunkGroupsKey`
+
+Type: `string`, `boolean`
+
+Default: `namedChunkGroups`
+
+If this is set to `false`, the `namedChunkGroups` will be added to the root of the manifest.
 
 ### `integrity`
 

--- a/src/WebpackAssetsManifest.js
+++ b/src/WebpackAssetsManifest.js
@@ -411,7 +411,7 @@ class WebpackAssetsManifest
   /**
    * @param {object} entrypoints from a compilation
    */
-  getEntrypointFilesGroupedByExtension( entrypoints )
+  getChunkGroupFilesGroupedByExtension( chunkGroups )
   {
     const files = Object.create(null);
     const removeHMR = f => ! this.isHMR(f);
@@ -424,8 +424,8 @@ class WebpackAssetsManifest
       return files;
     };
 
-    for ( const [ name, entrypoint ] of entrypoints ) {
-      files[ name ] = entrypoint
+    for ( const [ name, chunkGroup ] of chunkGroups ) {
+      files[ name ] = chunkGroup
         .getFiles()
         .filter( removeHMR )
         .reduce( groupFilesByExtension, Object.create(null) );
@@ -464,7 +464,7 @@ class WebpackAssetsManifest
     }
 
     if ( this.options.entrypoints ) {
-      const entrypoints = this.getEntrypointFilesGroupedByExtension( compilation.entrypoints );
+      const entrypoints = this.getChunkGroupFilesGroupedByExtension( compilation.entrypoints );
 
       if ( this.options.entrypointsKey === false ) {
         for ( const key in entrypoints ) {

--- a/src/WebpackAssetsManifest.js
+++ b/src/WebpackAssetsManifest.js
@@ -171,6 +171,10 @@ class WebpackAssetsManifest
       entrypoints: false,
       entrypointsKey: 'entrypoints',
 
+      // Include `compilation.namedChunkGroups` in the manifest file
+      namedChunkGroups: false,
+      namedChunkGroupsKey: 'namedChunkGroups',
+
       // https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
       integrity: false,
       integrityHashes: [ 'sha256', 'sha384', 'sha512' ],
@@ -472,6 +476,18 @@ class WebpackAssetsManifest
         }
       } else {
         this.setRaw( this.options.entrypointsKey, entrypoints );
+      }
+    }
+
+    if ( this.options.namedChunkGroups ) {
+      const namedChunkGroups = this.getChunkGroupFilesGroupedByExtension( compilation.namedChunkGroups );
+
+      if ( this.options.namedChunkGroupsKey === false ) {
+        for ( const key in namedChunkGroups ) {
+          this.setRaw( key, namedChunkGroups[ key ] );
+        }
+      } else {
+        this.setRaw( this.options.namedChunkGroupsKey, namedChunkGroups );
       }
     }
 

--- a/src/WebpackAssetsManifest.js
+++ b/src/WebpackAssetsManifest.js
@@ -429,8 +429,8 @@ class WebpackAssetsManifest
     };
 
     for ( const [ name, chunkGroup ] of chunkGroups ) {
-      files[ name ] = chunkGroup
-        .getFiles()
+      files[ name ] = this
+        .getChunkGroupFiles( chunkGroup )
         .filter( removeHMR )
         .reduce( groupFilesByExtension, Object.create(null) );
     }
@@ -678,6 +678,27 @@ class WebpackAssetsManifest
         return target.delete(property);
       },
     });
+  }
+
+  /**
+   * Get all files for a chunkGroup in webpack <= 4.4.1
+   *
+   * @param  {object} chunkGroup
+   * @return {Array}
+   */
+  getChunkGroupFiles(chunkGroup)
+  {
+    if (chunkGroup.getFiles) return chunkGroup.getFiles();
+
+    const files = new Set();
+
+    chunkGroup.chunks.forEach( chunkGroup => {
+      chunkGroup.files.forEach( file => {
+        files.add(file);
+      });
+    });
+
+    return Array.from(files);
   }
 }
 

--- a/test/WebpackAssetsManifest-test.js
+++ b/test/WebpackAssetsManifest-test.js
@@ -844,6 +844,69 @@ describe('WebpackAssetsManifest', function() {
       });
     });
 
+    describe('namedChunkGroups', function() {
+      it('namedChunkGroups are included in manifest', function(done) {
+        const compiler = makeCompiler(configs.dynamicImport());
+        const manifest = new WebpackAssetsManifest({
+          namedChunkGroups: true,
+        });
+
+        manifest.apply(compiler);
+
+        compiler.run(function( err ) {
+          assert.isNull(err, 'Error found in compiler.run');
+
+          const namedChunkGroups = manifest.get('namedChunkGroups');
+
+          assert.typeOf(namedChunkGroups.foo, 'object');
+
+          done();
+        });
+      });
+    });
+
+    describe('namedChunkGroupsKey', function() {
+      it('customize the key used for namedChunkGroups', function(done) {
+        const compiler = makeCompiler(configs.dynamicImport());
+        const manifest = new WebpackAssetsManifest({
+          namedChunkGroups: true,
+          namedChunkGroupsKey: 'myNamedChunkGroups',
+        });
+
+        manifest.apply(compiler);
+
+        compiler.run(function( err ) {
+          assert.isNull(err, 'Error found in compiler.run');
+
+          const namedChunkGroups = manifest.get('myNamedChunkGroups');
+
+          assert.typeOf(namedChunkGroups, 'object');
+
+          done();
+        });
+      });
+
+      it('can be false', function(done) {
+        const compiler = makeCompiler(configs.dynamicImport());
+        const manifest = new WebpackAssetsManifest({
+          namedChunkGroups: true,
+          namedChunkGroupsKey: false,
+        });
+
+        manifest.apply(compiler);
+
+        compiler.run(function( err ) {
+          assert.isNull(err, 'Error found in compiler.run');
+
+          const namedChunkGroup = manifest.get('main');
+
+          assert.typeOf(namedChunkGroup, 'object');
+
+          done();
+        });
+      });
+    });
+
     describe('done', function() {
       it('is called when compilation is done', function(done) {
         const compiler = makeCompiler(configs.hello());

--- a/test/fixtures/configs.js
+++ b/test/fixtures/configs.js
@@ -42,6 +42,18 @@ function hello()
   };
 }
 
+function dynamicImport()
+{
+  return {
+    mode: 'development',
+    entry: path.resolve(__dirname, './dynamicImport.js'),
+    output: {
+      path: tmpDirPath(),
+      filename: 'bundle.js',
+    },
+  };
+}
+
 function client()
 {
   return {
@@ -141,6 +153,7 @@ function multi()
 
 module.exports = {
   hello,
+  dynamicImport,
   client,
   server,
   devServer,

--- a/test/fixtures/dynamicImport.js
+++ b/test/fixtures/dynamicImport.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  import(/* webpackChunkName: "foo" */ './hello');
+};


### PR DESCRIPTION
This PR enables the inclusion of `namedChunkGroups` in the outputted manifest file. It works similarly to `entrypoints`, but includes all named chunk groups – including dynamically loaded ones.

For example, if we have an entrypoint like this:

```js
import(/* webpackChunkName: "some-dynamic-import" */ 'some-module');
```

…using the `namedChunkGroups` option will produce a manifest like:

```json
{
  "namedChunkGroups": {
    "some-entrypoint": {
      "js": [
        "some-entrypoint.js"
      ]
    },
    "some-dynamic-import": {
      "js": [
        "some-dependency.js",
        "some-module.js"
      ],
      "css": [
        "some-dependency.css",
        "some-module.css"
      ]
    }
  }
}
```

This could be useful for adding stylesheet link tags or preloading assets for modules we know are going to be dynamically loaded.