### PR TITLE
output assets without a chunk name, should fix #49

### DIFF
--- a/src/WebpackAssetsManifest.js
+++ b/src/WebpackAssetsManifest.js
@@ -360,6 +360,23 @@ class WebpackAssetsManifest
   }
 
   /**
+   * Process compilation assets without a chunk name.
+   *
+   * @param  {object} assets - All assets
+   * @return {object}
+   */
+  processAssetsWithoutChunkNames(assets)
+  {
+    assets.filter(asset => asset.chunkNames.length === 0).map(asset => {
+      const { name } = asset;
+
+      this.assetNames.set( name, name);
+    });
+
+    return this.assetNames;
+  }
+
+  /**
    * Get the data for `JSON.stringify()`.
    *
    * @return {object}
@@ -440,9 +457,11 @@ class WebpackAssetsManifest
     this.stats = compilation.getStats().toJson({
       all: false,
       assets: true,
+      cachedAssets: true,
     });
 
     this.processAssetsByChunkName( this.stats.assetsByChunkName );
+    this.processAssetsWithoutChunkNames(this.stats.assets);
 
     for ( const [ hashedFile, filename ] of this.assetNames ) {
       this.currentAsset = compilation.assets[ hashedFile ];

--- a/test/WebpackAssetsManifest-test.js
+++ b/test/WebpackAssetsManifest-test.js
@@ -1311,4 +1311,34 @@ describe('WebpackAssetsManifest', function() {
       });
     });
   });
+
+  describe('Works with assets without a chunk name', () => {
+    it('Assets show up in manifest', function(done) {
+      const CopyPlugin = require('./mocks/CopyPluginMock');
+      const copy = new CopyPlugin([
+        {
+          targetPath: 'test.txt',
+          data: Buffer.from('test', 'utf-8'),
+        },
+      ]);
+      const manifest = new WebpackAssetsManifest({
+        space: 0,
+      });
+      const compiler = makeCompiler(configs.bare());
+
+      copy.apply(compiler);
+      manifest.apply(compiler);
+
+      compiler.run(function(err) {
+        assert.isNull(err, 'Error found in compiler.run');
+
+        assert.equal(
+          '{"test.txt":"test.txt"}',
+          manifest.toString()
+        );
+
+        done();
+      });
+    });
+  });
 });

--- a/test/fixtures/configs.js
+++ b/test/fixtures/configs.js
@@ -137,6 +137,16 @@ function multi()
   return [ c, s ];
 }
 
+function bare()
+{
+  return {
+    mode: 'development',
+    output: {
+      path: tmpDirPath(),
+    },
+  };
+}
+
 module.exports = {
   hello,
   client,
@@ -147,4 +157,5 @@ module.exports = {
   tmpDirPath,
   getWorkspace,
   styles,
+  bare,
 };

--- a/test/mocks/CopyPluginMock.js
+++ b/test/mocks/CopyPluginMock.js
@@ -1,0 +1,30 @@
+const webpack = require('webpack');
+
+const { RawSource } = webpack.sources || require('webpack-sources');
+
+class CopyPluginMock {
+  constructor(assets) {
+    this.assets = assets;
+  }
+
+  apply(compiler) {
+    const pluginName = this.constructor.name;
+
+    compiler.hooks.thisCompilation.tap(pluginName, compilation => {
+      compilation.hooks.additionalAssets.tapAsync(
+        pluginName,
+        async callback => {
+          this.assets.forEach(asset => {
+            const { targetPath, data } = asset;
+            const source = new RawSource(data);
+
+            compilation.emitAsset(targetPath, source, {});
+          });
+          callback();
+        }
+      );
+    });
+  }
+}
+
+module.exports = CopyPluginMock;


### PR DESCRIPTION
*  Disclaimer: I do not have that much experience with Webpack plugin development... 
* Addresses #49 and #98
* Initial PR - I am willing to put some more work into it - if desired. More tests etc.
* I left the existing `processAssetsByChunkName` logic intact. 
* Adds assets from Copy Plugin and `import()`.

