### PR TITLE
Make the lockfile specific to a process

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -170,7 +170,7 @@ function getLockFilename( filename )
 {
   const name = filename.replace(/[^\w]+/g, '-');
 
-  return path.join( os.tmpdir(), `${name}.lock` );
+  return path.join( os.tmpdir(), `${name}-${process.pid}.lock` );
 }
 
 /**


### PR DESCRIPTION
This contribution makes sure the lockfile is not re-used by different unrelated processes. This situation might happen if you run multiple Webpack builds in parallel. In some situations it might even crash one of the Webpack build with an error looking like that:

```
node:fs:1142
  handleErrorFromBinding(ctx);
  ^
Error: ENOENT: no such file or directory, stat '/path/to/tmp/folder/manifest-json.lock'
    at Object.statSync (node:fs:1142:3)
    at Object.exports.lockSync (/path/to/sources/node_modules/lockfile/lockfile.js:286:19)
    at lockSync (/path/to/sources/node_modules/webpack-assets-manifest/src/helpers.js:221:19)
    at WebpackAssetsManifest.emitAssetsManifest (/path/to/sources/node_modules/webpack-assets-manifest/src/WebpackAssetsManifest.js:447:7)
    at WebpackAssetsManifest.handleAfterProcessAssets (/path/to/sources/node_modules/webpack-assets-manifest/src/WebpackAssetsManifest.js:593:10)
    at Hook.eval [as call] (eval at create (/path/to/sources/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:19:10), <anonymous>:7:1)
    at Hook.CALL_DELEGATE [as _call] /path/to/sources/node_modules/webpack/node_modules/tapable/lib/Hook.js:14:14)
    at /path/to/sources/node_modules/webpack/lib/Compilation.js:2397:40
    at eval (eval at create (/path/to/sources/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
    at fn (/path/to/sources/node_modules/webpack/lib/Compilation.js:387:9)
    at _next1 (eval at create (/path/to/sources/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:11:1)
    at eval (eval at create (/path/to/sources/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:27:1)
    at processTicksAndRejections (node:internal/process/task_queues:94:5) {
  errno: -2,
  syscall: 'stat',
  code: 'ENOENT',
  path: '/path/to/tmp/folder/manifest-json.lock'
```