### PR TITLE
Lockfile improvements

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
-        webpack-version: ['5.1.0', 5]
+        webpack-version: ['5.2.0', 5]
         dev-server-version: ['3.6.0', latest]
         css-loader-version: ['3.5.0', latest]
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1999,9 +1999,9 @@
       }
     },
     "css-loader": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.0.tgz",
-      "integrity": "sha512-MfRo2MjEeLXMlUkeUwN71Vx5oc6EJnx5UQ4Yi9iUtYQvrPtwLUucYptz0hc6n++kdNcyF5olYBS4vPjJDAcLkw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.1.tgz",
+      "integrity": "sha512-YCyRzlt/jgG1xanXZDG/DHqAueOtXFHeusP9TS478oP1J++JSKOyEgGW1GHVoCj/rkS+GWOlBwqQJBr9yajQ9w==",
       "dev": true,
       "requires": {
         "camelcase": "^6.2.0",
@@ -5311,16 +5311,22 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.2.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.8.tgz",
-      "integrity": "sha512-1F0Xb2T21xET7oQV9eKuctbM9S7BC0fetoHCc4H13z0PT6haiRLP4T0ZY4XWh7iLP0usgqykT6p9B2RtOf4FPw==",
+      "version": "8.2.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
+      "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
       "dev": true,
       "requires": {
         "colorette": "^1.2.2",
-        "nanoid": "^3.1.20",
+        "nanoid": "^3.1.22",
         "source-map": "^0.6.1"
       },
       "dependencies": {
+        "nanoid": {
+          "version": "3.1.22",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
+          "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "tapable": "^2.0"
   },
   "peerDependencies": {
-    "webpack": "^5.1.0"
+    "webpack": "^5.2.0"
   },
   "devDependencies": {
     "@types/lodash.get": "^4.4.6",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "compression-webpack-plugin": "^7.1.2",
     "copy-webpack-plugin": "^8.1.1",
     "cspell": "^5.3.12",
-    "css-loader": "^5.0.2",
+    "css-loader": "^5.2.1",
     "eslint": "^7.19.0",
     "file-loader": "^6.2.0",
     "fs-extra": "^9.1.0",

--- a/src/WebpackAssetsManifest.js
+++ b/src/WebpackAssetsManifest.js
@@ -28,8 +28,6 @@ const {
   findMapKeysByValue,
   lock,
   unlock,
-  lockSync,
-  unlockSync,
 } = require('./helpers.js');
 
 /** @type {object} */
@@ -415,7 +413,7 @@ class WebpackAssetsManifest
    *
    * @param {object} compilation
    */
-  emitAssetsManifest(compilation)
+  async emitAssetsManifest(compilation)
   {
     const outputPath = this.getOutputPath();
 
@@ -427,7 +425,7 @@ class WebpackAssetsManifest
     );
 
     if ( this.options.merge ) {
-      lockSync( outputPath );
+      await lock( outputPath );
     }
 
     this.maybeMerge();
@@ -441,7 +439,7 @@ class WebpackAssetsManifest
     );
 
     if ( this.options.merge ) {
-      unlockSync( outputPath );
+      await unlock( outputPath );
     }
   }
 
@@ -540,7 +538,7 @@ class WebpackAssetsManifest
    *
    * @param {object} compilation
    */
-  handleAfterProcessAssets( compilation )
+  async handleProcessAssetsReport( compilation )
   {
     // Look in DefaultStatsPresetPlugin.js for options
     const stats = compilation.getStats().toJson({
@@ -632,7 +630,7 @@ class WebpackAssetsManifest
       }
     }
 
-    this.emitAssetsManifest(compilation);
+    await this.emitAssetsManifest(compilation);
   }
 
   /**
@@ -799,15 +797,21 @@ class WebpackAssetsManifest
   handleThisCompilation(compilation)
   {
     if ( this.options.integrity ) {
-      compilation.hooks.afterProcessAssets.tap(
-        PLUGIN_NAME,
+      compilation.hooks.processAssets.tap(
+        {
+          name: PLUGIN_NAME,
+          stage: Compilation.PROCESS_ASSETS_STAGE_ANALYSE,
+        },
         this.recordSubresourceIntegrity.bind(this, compilation),
       );
     }
 
-    compilation.hooks.afterProcessAssets.tap(
-      PLUGIN_NAME,
-      this.handleAfterProcessAssets.bind(this, compilation),
+    compilation.hooks.processAssets.tapPromise(
+      {
+        name: PLUGIN_NAME,
+        stage: Compilation.PROCESS_ASSETS_STAGE_REPORT,
+      },
+      this.handleProcessAssetsReport.bind(this, compilation),
     );
   }
 

--- a/src/WebpackAssetsManifest.js
+++ b/src/WebpackAssetsManifest.js
@@ -417,15 +417,17 @@ class WebpackAssetsManifest
    */
   emitAssetsManifest(compilation)
   {
+    const outputPath = this.getOutputPath();
+
     const output = this.getManifestPath(
       compilation,
       this.inDevServer() ?
         path.basename( this.options.output ) :
-        path.relative( compilation.compiler.outputPath, this.getOutputPath() ),
+        path.relative( compilation.compiler.outputPath, outputPath ),
     );
 
     if ( this.options.merge ) {
-      lockSync( output );
+      lockSync( outputPath );
     }
 
     this.maybeMerge();
@@ -439,7 +441,7 @@ class WebpackAssetsManifest
     );
 
     if ( this.options.merge ) {
-      unlockSync( output );
+      unlockSync( outputPath );
     }
   }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -161,6 +161,11 @@ function group( arr, getGroup, mapper = item => item )
   );
 }
 
+function md5( data )
+{
+  return crypto.createHash('md5').update( data ).digest('hex');
+}
+
 /**
  * Build a file path to a lock file in the tmp directory
  *
@@ -168,9 +173,10 @@ function group( arr, getGroup, mapper = item => item )
  */
 function getLockFilename( filename )
 {
-  const name = filename.split(/[^\w]+/).filter( Boolean ).join('-');
+  const name = path.basename( filename );
+  const dirHash = md5( path.dirname( filename ) );
 
-  return path.join( os.tmpdir(), `${name}.lock` );
+  return path.join( os.tmpdir(), `${dirHash}-${name}.lock` );
 }
 
 /**
@@ -187,7 +193,6 @@ async function lock( filename )
       retryWait: 100,
       stale: 10000,
       retries: 100,
-
     },
   );
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -168,7 +168,7 @@ function group( arr, getGroup, mapper = item => item )
  */
 function getLockFilename( filename )
 {
-  const name = filename.replace(/[^\w]+/g, '-');
+  const name = filename.split(/[^\w]+/).filter( Boolean ).join('-');
 
   return path.join( os.tmpdir(), `${name}.lock` );
 }
@@ -184,9 +184,10 @@ async function lock( filename )
     getLockFilename( filename ),
     {
       wait: 10000,
-      stale: 20000,
-      retries: 100,
       retryWait: 100,
+      stale: 10000,
+      retries: 100,
+
     },
   );
 }
@@ -201,8 +202,9 @@ function lockSync( filename )
   return lockfile.lockSync(
     getLockFilename( filename ),
     {
-      stale: 20000,
-      retries: 200,
+      // wait and retryWait are not supported in lockSync
+      stale: 10000,
+      retries: 100,
     },
   );
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -189,26 +189,9 @@ async function lock( filename )
   await lfLock(
     getLockFilename( filename ),
     {
-      wait: 10000,
+      wait: 6000,
       retryWait: 100,
-      stale: 10000,
-      retries: 100,
-    },
-  );
-}
-
-/**
- * Create a lockfile
- *
- * @param {string} filename
- */
-function lockSync( filename )
-{
-  return lockfile.lockSync(
-    getLockFilename( filename ),
-    {
-      // wait and retryWait are not supported in lockSync
-      stale: 10000,
+      stale: 5000,
       retries: 100,
     },
   );
@@ -224,16 +207,6 @@ async function unlock( filename )
   await lfUnlock( getLockFilename( filename ) );
 }
 
-/**
- * Remove a lockfile
- *
- * @param {string} filename
- */
-function unlockSync( filename )
-{
-  return lockfile.unlockSync( getLockFilename( filename ) );
-}
-
 module.exports = {
   maybeArrayWrap,
   filterHashes,
@@ -246,7 +219,5 @@ module.exports = {
   group,
   getLockFilename,
   lock,
-  lockSync,
   unlock,
-  unlockSync,
 };


### PR DESCRIPTION
- Updated hook being used to process assets.
  Use `processAssets` hook instead of `afterProcessAssets` so that async lock/unlock functions can be used.
- Updated `getLockFilename()` to use hash of `dirname`.
- Removed `lockSync` and `unlockSync` functions.
- Updated min webpack version to `5.2`.

Closes #147 
