### PR TITLE
Fix excessive or doubled integrity hashes when used with webpack-subresource-integrity

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -764,6 +764,7 @@ export class WebpackAssetsManifest implements WebpackPluginInstance {
         // webpack-subresource-integrity@4+ stores the integrity hash on `asset.info.contenthash`.
         if (asset.info.contenthash) {
           asArray(asset.info.contenthash)
+            .flatMap((contentHash) => contentHash.split(' '))
             .filter((contentHash) => integrityHashes.some((algorithm) => contentHash.startsWith(`${algorithm}-`)))
             .forEach((sriHash) => sriHashes.set(sriHash.substring(0, sriHash.indexOf('-')), sriHash));
         }


### PR DESCRIPTION
Address #287 
Simply splitting webpack-subresource-integrity plugin contentHash before reusing.