### PR TITLE
fix: ignore `ENOENT` error during merge

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -5,6 +5,7 @@
     "Analyse",
     "chunkhash",
     "conventionalcommits",
+    "ENOENT",
     "nvmrc",
     "postbuild",
     "subresource",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -422,6 +422,13 @@ export class WebpackAssetsManifest implements WebpackPluginInstance {
             this.set(key, oldValue);
           }
         }
+      } catch (error) {
+        // Ignore ENOENT errors when merging.
+        if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+          return;
+        }
+
+        throw error;
       } finally {
         this.#isMerging = false;
       }

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -523,6 +523,14 @@ describe('Options', () => {
       );
     });
 
+    it('Should not error if output file does not exist before merging', async () => {
+      const { run } = create(configs.hello(), {
+        merge: true,
+      });
+
+      await expect(run()).resolves.not.toThrow();
+    });
+
     it('Can customize during merge', async () => {
       const mergingResults: boolean[] = [];
       const { manifest, run } = create(configs.hello(), {


### PR DESCRIPTION
Ignore `ENOENT` error during merge. All other caught errors will be rethrown.

Related #300 