### PR TITLE
chore: use public repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/webdeveric/webpack-assets-manifest.git"
+    "url": "git+https://github.com/webdeveric/webpack-assets-manifest.git"
   },
   "bugs": {
     "url": "https://github.com/webdeveric/webpack-assets-manifest/issues"


### PR DESCRIPTION
## Summary
- update the npm `repository.url` metadata to use the public HTTPS GitHub URL
- leave runtime code, dependencies, package version, homepage, bugs metadata, and package contents unchanged

## Why
The published npm metadata currently points at the SSH GitHub URL, which is less convenient for users browsing package metadata without GitHub SSH access. The repository is public, so `git+https` is the more accessible package metadata URL.

## Validation
- `npm view webpack-assets-manifest repository homepage bugs --json`
- metadata assertion comparing the updated `repository.url` while preserving `homepage` and `bugs.url`
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm run lint`
- `corepack pnpm run build`
- `corepack pnpm run test -- --run` (3 files, 131 passed, 1 todo)
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`
